### PR TITLE
Feat: checkmate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,5 +14,6 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Imports: 
+    checkmate (>= 2.3.2),
     dplyr,
     stringr

--- a/R/checker_df.R
+++ b/R/checker_df.R
@@ -4,6 +4,15 @@
 # Process as NA/0 for purposes of aggregation, but input special char. for purposes
 # of printing
 
+# Response:
+# That is a cool idea - and I kinda want to do it for fun because I think
+# that would be useful for many things and I don't know how I would do
+# that in something like R. However - folks, or pipelines
+# will already have access to the raw data in memory to give the functions.
+# So they will have an unsuppressed version - so I we should return a suppressed
+# dataframe to keep it simple to get the job done - but we should circle back
+# to that - also we should get a github project going for discussions :D
+
 #' Check a dataframe for current suppression
 #'
 #' @param df Dataframe to be checked.

--- a/R/checker_df.R
+++ b/R/checker_df.R
@@ -23,27 +23,47 @@
 #' @export
 #'
 #' @examples
-#' x <- data.frame(x = c('2', '*', '*', '3', '5', '2'),y = c('*', '3', '5', '*', '2', '*'))
+#' x <-
+#'  data.frame(
+#'    x = c('2', '*', '*', '3', '5', '2'),
+#'    y = c('*', '3', '5', '*', '2', '*')
+#' )
 #'
 #' checker_df(x, c('x','y'), '\\*')
 #' checker_df(x, c('x'), '2')
 checker_df <- function(df, supp_col, regex_char) {
-  stopifnot(
-    inherits(df, 'data.frame'),
-    inherits(regex_char, 'character') | inherits(regex_char, 'numeric'),
-    nrow(df) > 0,
-    ncol(df) > 0 ,
-    regex_char != '',
-    length(supp_col) > 0,
-    supp_col %in% names(df)
-    )
-  if (inherits(regex_char,'numeric')) {
-    regex_char = as.character(regex_char)
-  }
-  checker <- df |>
-    # If a value has been suppressed, replace it with 1.
-    # If a value has not been suppressed, replace it with 0.
-    dplyr::mutate_at(supp_col, ~ as.numeric(stringr::str_detect(., regex_char)))
+  # Check User Input
+  checkmate::assert(
+    checkmate::check_data_frame(
+      df,
+      min.rows = 1,
+      min.cols = 1
+    ),
+    checkmate::check_character(
+      supp_col,
+      min.len = 1
+    ),
+    checkmate::check_subset(supp_col, names(df)),
+    combine = "and"
+  )
 
-  return (checker)
+  checkmate::assert(
+    checkmate::check_character(regex_char, min.chars = 1, all.missing = FALSE),
+    checkmate::check_numeric(regex_char),
+    combine = "or"
+  )
+
+  # If a value has been suppressed, replace it with 1.
+  # If a value has not been suppressed, replace it with 0.
+  df |>
+    dplyr::mutate(
+      dplyr::across(
+        dplyr::all_of(supp_col),
+        \(col) {
+          as.numeric(
+            stringr::str_detect(col, regex_char)
+          )
+        }
+      )
+    )
 }

--- a/man/checker_df.Rd
+++ b/man/checker_df.Rd
@@ -20,7 +20,11 @@ A dataframe.
 Check a dataframe for current suppression
 }
 \examples{
-x <- data.frame(x = c('2', '*', '*', '3', '5', '2'),y = c('*', '3', '5', '*', '2', '*'))
+x <-
+ data.frame(
+   x = c('2', '*', '*', '3', '5', '2'),
+   y = c('*', '3', '5', '*', '2', '*')
+)
 
 checker_df(x, c('x','y'), '\\\\*')
 checker_df(x, c('x'), '2')

--- a/tests/testthat/test-checker_df.R
+++ b/tests/testthat/test-checker_df.R
@@ -3,27 +3,27 @@ test_that("checker_df() returns dataframe", {
     class(checker_df(
       data.frame(
         x = c('*', '3', '4'),
-        y = c('4','1','*')
-        ),
+        y = c('4', '1', '*')
+      ),
       c('x', 'y'),
       '\\*'
-      )),
-    'data.frame')
-  }
+    )),
+    'data.frame'
   )
+})
 
 test_that("checker_df() requires suppression columns", {
   expect_error(
     checker_df(
       data.frame(
         x = c('*', '3', '4'),
-        y = c('4','1','*')
+        y = c('4', '1', '*')
       ),
       c(),
       '\\*'
-    ))
-}
-)
+    )
+  )
+})
 
 test_that("checker_df() requires dataframe as input", {
   expect_error(
@@ -31,29 +31,29 @@ test_that("checker_df() requires dataframe as input", {
       "string as improper input that should throw error",
       c('x', 'y'),
       '\\*'
-    ))
-}
-)
+    )
+  )
+})
 
 test_that("checker_df() requires supp_col to be in df", {
   expect_error(
     checker_df(
       data.frame(
         x = c('*', '3', '4'),
-        y = c('4','1','*')
+        y = c('4', '1', '*')
       ),
       c('z', 'y'),
       '\\*'
-    ))
-}
-)
+    )
+  )
+})
 
 test_that("checker_df() allows number as regex character", {
   expect_equal(
     checker_df(
       data.frame(
         x = c('*', '3', '4'),
-        y = c('4','1','*')
+        y = c('4', '1', '*')
       ),
       c('x', 'y'),
       '4'
@@ -61,19 +61,19 @@ test_that("checker_df() allows number as regex character", {
     data.frame(
       x = c(0, 0, 1),
       y = c(1, 0, 0)
-    ))
-}
-)
+    )
+  )
+})
 
 test_that("checker_df() requires suppression character", {
   expect_error(
     checker_df(
       data.frame(
         x = c('*', '3', '4'),
-        y = c('4','1','*')
+        y = c('4', '1', '*')
       ),
       c('x', 'y'),
       ''
-    ))
-}
-)
+    )
+  )
+})


### PR DESCRIPTION
- Added `checkmate` >= 2.3.2 package for input validation
  - This is a decision point for you and how many dependencies you want to have:
    - `stopifnot()` works just fine
    - `checkmate` has lots of canned input validation so you don't have to think, with _decent_ error messages for end users, and a traceback.
    - Is the best option probably rolling your own error and error handling? like with `rlang` and `cli`... probably, but no one has time for that. So take a look at checkmate -  see if _you_ think it's work keeping as a dependency.
- misc formatting with `air`
 